### PR TITLE
[CORTX 2022 Hackathon] add cortx-terraform readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,0 +1,55 @@
+# Terraform Provider - Seagate CORTX
+
+
+This README refers to an integration between the CORTX API and Hashicorp [Terraform](https://www.terraform.io/). 
+
+You can refer to the following resources to learn more:
+
+- [Video](https://studio.youtube.com/video/m3MeDl-5jKE/edit)
+
+- [Source + Instructions](https://github.com/DMW2151/big-pile-of-storage)
+
+Infrastructure As Code tools like Terraform can allow organizations to standardize infrastructure and policies across multiple regions, environments, applications, etc. With the this provider, users can now include CORTX resources with their other infrastructure deployments rather than relying on custom scripts or one-off deployment patterns. This provider is opinionated in that it simplifies AWS' provider, abstracts away the elements of the S3 API that aren't applicable for CORTX, and provides a cleaner interface between Terraform and CORTX than the AWS provider can.
+
+
+## Building The Provider
+
+Terraform providers are [Golang](https://go.dev/dl/) modules. If you've got Go >=v1.17 on your machine, you can run the following command to build the provider locally. Please see notes in the MakeFile, you may need to change the `$TARGET_ARCH` and `$TARGET_OS` arguments to be compatible with your system's operating system and architecture before building.
+
+```bash 
+make install
+```
+
+## Examples - Using the Provider
+
+Please refer to the README in the Terraform provider repo for a full discussion of examples. For a quick (and free) test, I'd recommend running the CloudShare example. If you're familiar with Terraform, you may simply run `make install`, which will handle building and installing the provider. From there, declaring and initializing the CORTX provider is the same as any other Terraform provider. Consider the example below:
+
+```
+// Terraform Main Config //
+terraform {
+
+  // Provider Versions
+  required_providers {
+    cortx = {
+      version = "0.0.1"
+      source  = "dmw2151.com/terraform/cortx"
+    }
+  }
+
+  // Terraform Version
+  required_version = ">= 1.0.3"
+
+}
+
+// CORTX Provider Config //
+provider "cortx" {
+  // CORTX Connection Configuration 
+  cortx_endpoint_host = "localhost"
+  cortx_endpoint_port = "28001"
+
+  // CORTX User Configuration
+  cortx_access_key        = "..."
+  cortx_secret_access_key = "..."
+}
+```
+


### PR DESCRIPTION
add cortx-terraform readme - see comments in readme


### Describe your changes in brief

Adds readme for CORTX terraform provider integration

### Changes
 - [x] Why is this change required? - What problem does it solve? - Hackathon feature. Builds a integration between the CORTX API and Hashicorp [Terraform](https://www.terraform.io/). Infrastructure As Code tools like Terraform can allow organizations to standardize infrastructure and policies across multiple regions, environments, applications, etc. With the this provider, users can now include CORTX resources with their other infrastructure deployments rather than relying on custom scripts or one-off deployment patterns. 

 - [x] If proposing a new change then please raise an issue first

### How Has This Been Tested? (Optional)
 - [x] Please describe in detail how you tested your changes. - Tested on AWS C5.large instance (v1.04) following guide from [CORTX EC2 Setup Guide](https://github.com/Seagate/cortx/blob/main/doc/integrations/AWS_EC2/README.md) and on a one-off Cloudshare instance (v2.0.0-790).

 - [x] Include details of your testing environment, and the tests you ran to - N.A - external to MOTR or CORTX functionality, just adds provider functionality. Build depends on Terraform > v1.0.3 and Go > v1.16.

 - [x] How your change affects other areas of the code, etc.

### Screenshots (if appropriate)

- Refer to video description in readme.md

### Checklist
 - [x] tested locally
 - [x] added new dependencies
 - [x] updated the docs
 - [x] added a test
